### PR TITLE
Support for JDK 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,19 @@ Besides the educational value, this project will be used to test and tune compil
 This port used [llama2.scala](https://github.com/jrudolph/llama2.scala) initially as a reference.
 
 ## Build
-Java 20+ is required, in particular the [`MemorySegment` mmap-ing feature](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/nio/channels/FileChannel.html#map(java.nio.channels.FileChannel.MapMode,long,long,java.lang.foreign.SegmentScope)).  
+Java 21+ is required, in particular the [`MemorySegment` mmap-ing feature](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/nio/channels/FileChannel.html#map(java.nio.channels.FileChannel.MapMode,long,long,java.lang.foreign.SegmentScope)).  
+
 The code expects [`tokenizer.bin`](https://github.com/karpathy/llama2.c/raw/master/tokenizer.bin) in the current directory.
+You can use [TinyStories](https://huggingface.co/karpathy/tinyllamas/tree/main) checkpoints or get LLama2 models by [following instructions](https://github.com/karpathy/llama2.c#metas-llama-2-models).
+
+```bash
+wget https://github.com/karpathy/llama2.c/raw/master/tokenizer.bin
+wget https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin
+```
 
 To build and run manually:
 ```bash
-javac --enable-preview -source 20 --add-modules=jdk.incubator.vector Llama2.java
+javac --enable-preview -source 21 --add-modules=jdk.incubator.vector Llama2.java
 java --enable-preview --add-modules=jdk.incubator.vector Llama2 stories15M.bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Besides the educational value, this project will be used to test and tune compil
 This port used [llama2.scala](https://github.com/jrudolph/llama2.scala) initially as a reference.
 
 ## Build
-Java 21+ is required, in particular the [`MemorySegment` mmap-ing feature](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/nio/channels/FileChannel.html#map(java.nio.channels.FileChannel.MapMode,long,long,java.lang.foreign.SegmentScope)).  
+Java 21+ is required, in particular the [`MemorySegment` mmap-ing feature](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/nio/channels/FileChannel.html#map(java.nio.channels.FileChannel.MapMode,long,long,java.lang.foreign.Arena)).  
 
 The code expects [`tokenizer.bin`](https://github.com/karpathy/llama2.c/raw/master/tokenizer.bin) in the current directory.
 You can use [TinyStories](https://huggingface.co/karpathy/tinyllamas/tree/main) checkpoints or get LLama2 models by [following instructions](https://github.com/karpathy/llama2.c#metas-llama-2-models).


### PR DESCRIPTION
This PR updates the JDK version from 20 to 21 and updates README to add download command for tokenizer and stories dataset.

**JDK 21 Changes**

JDK 21 includes the [third preview](https://openjdk.org/jeps/442) of Foreign Function & Memory API. In this third preview, compared to JDK 20, `SegmentScope` is now replaced with `Arena`. As result, the current `main` branch does not compile with JDK 21.

JDK 21 is the **LTS version**, and will see much greater adoption than JDK 20. Note, once this PR is merged, `llama2.java` will only work with JDK 21 and will no longer compile with JDK 20.

**README changes**

Currently the README expects the user to have read the README from [llama2.c](https://github.com/karpathy/llama2.c) which may not be the case for users who first came to this repository. As a convenience, the README is updated, for such users so they can quickly get started without having to look for where to download `stories15M.bin`